### PR TITLE
fix res leak: remove panel dom node on closing tab

### DIFF
--- a/src/components/tabs/tab-bar.tsx
+++ b/src/components/tabs/tab-bar.tsx
@@ -120,7 +120,12 @@ const TabBar = (props: TabBarProps) => {
       }
 
     }
-    tabBar.current.removeChild(document.getElementById(id));
+
+    const tabNode = document.getElementById(id);
+    tabBar.current.removeChild(tabNode);
+
+    const panelNode = document.getElementById(`${id}-panel`);
+    panelNode.parentNode.removeChild(panelNode);
   };
 
   const setActive = (tabId: string, e: any) => {


### PR DESCRIPTION
Close https://github.com/EvoluxBR/react-smart-tabs/issues/12

(This also fixes another bug: when all tabs are removed, without this PR the last panel is still visible.)
